### PR TITLE
Remove needless statement

### DIFF
--- a/components/mapPieceClass.js
+++ b/components/mapPieceClass.js
@@ -13,8 +13,6 @@ MapPiece.prototype.setBlock = function(block){
   this.block = block;
   block.x = this.x;
   block.y = this.y;
-
-  this.renderBlock();
 };
 
 MapPiece.prototype.setBlockType = function(type){


### PR DESCRIPTION
Name of the method does not indicate, that the block will be rendered. It can easily lead to mistake like this one: https://github.com/HiperNova/mini_universe/blob/master/controllers/mapController.js#L13 - you call setBlock and then you call render, because you didn't remember (and you shouldn't have to remember), that this method renders block beside doing what its name suggests.